### PR TITLE
Add Ambire Wallet to list of AA wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 
 ### Smart Contracts (EVM)
 
+- [Ambire Wallet](https://github.com/AmbireTech/wallet/tree/development/contracts)
 - [Biconomy](https://github.com/bcnmy/scw-contracts)
 - [BLS Wallet](https://github.com/web3well/bls-wallet/tree/main/contracts)
 - [Candide Wallet](https://github.com/candidelabs/CandideWalletContracts)


### PR DESCRIPTION
## Summary
Ambire Wallet added ERC 4337 support today, added it including a URL to the implementation.