### PR TITLE
add Safe to Smart contracts and Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 - [zerodevapp/core](https://github.com/zerodevapp/core)
 - [etherspot-sdk](https://github.com/etherspot/etherspot-sdk)
 - [web3well/easy-web3](https://github.com/web3well/easy-web3)
+- [safe-global/safe-core-sdk](https://github.com/safe-global/safe-core-sdk)
 
 ### Smart Contracts (EVM)
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@
 - [Stackup](https://github.com/stackup-wallet/stackup)
 - [Soul Wallet](https://github.com/proofofsoulprotocol/soul-wallet-contract)
 - [Etherspot](https://github.com/etherspot/etherspot-contracts/)
+- [Safe](https://github.com/safe-global/safe-contracts/)
 
 ### Bundlers
 
@@ -138,6 +139,7 @@ Projects using Account Abstraction (or variations of AA) in alphabetical order.
 - [Fluvi](https://fluvi.io/)
 - [Openfort](https://openfort.xyz)
 - [Peaze](https://www.peaze.com/)
+- [Safe](https://safe.global/)
 - [Solon Network](https://www.solon.network/)
 - [Soul Wallet](https://twitter.com/soulwallet_eth)
 - [Stackup](https://stackup.sh/)


### PR DESCRIPTION
Safe uses Account Abstraction and is 4337 compatible.

See: https://github.com/eth-infinitism/account-abstraction/pull/96