### PR TITLE
Add 403 to lychee

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -15,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.1
         with:
-          args: --accept 200 README.md
+          args: --accept 200,403 README.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         


### PR DESCRIPTION
Added 403 status code to lynchee link checker. 
Dune sometimes responds with 403 when url is pinged by a bot but this doesn't mean that URL is down.
Closes #42 #43 #44 #45 