### PR TITLE
Update README.md - L2 integration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@
 
 - [Account Abstraction RPC Providers](https://github.com/arddluma/awesome-list-rpc-nodes-providers#account-abstraction-rpc-providers)
 
+### L2 Integration API
+
+- [Integration API for EIP-4337 bundler with an L2 validator/sequencer](https://notes.ethereum.org/@yoav/SkaX2lS9j)
+
 # Projects
 
 Projects using Account Abstraction (or variations of AA) in alphabetical order.


### PR DESCRIPTION
Add section for L2 under "Code" for Yoav's HackMD article about integration API for L2 sequencers. Am looking around to see if there's an associated github repo for this too