### PR TITLE
Add Ambire to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 Projects using Account Abstraction (or variations of AA) in alphabetical order.
 
 - [0xPass](https://0xpass.io/)
+- [Ambire](https://www.ambire.com)
 - [Argent](https://www.argent.xyz/)
 - [Braavos](https://braavos.app/)
 - [Biconomy](https://www.biconomy.io/)


### PR DESCRIPTION
## Summary

Add Ambire to projects. Not Ambire Wallet specifically, since Ambire AdEx also uses AA