### PR TITLE
Add EIP-7377 for EOA to AA migration transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [EIP-5792: Wallet Function Call API](https://eips.ethereum.org/EIPS/eip-5792)
 - [EIP-6492: Signature Validation for Predeploy Contracts](https://eips.ethereum.org/EIPS/eip-6492)
 - [EIP-6900: Modular Smart Contract Accounts and Plugins](https://eips.ethereum.org/EIPS/eip-6900)
+- [EIP-7377: (AA) Migration Transaction](https://eips.ethereum.org/EIPS/eip-7377)
 
 
 ### EIP Articles & Discussions


### PR DESCRIPTION
Add EIP-7377, which proposes to create the ability to submit a one-time code deployment to EOAs, turning them into AA accounts.

see also https://ethereum-magicians.org/t/eip-7377-migration-transaction/15144