### PR TITLE
Add aaexplorer.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Projects using Account Abstraction (or variations of AA) in alphabetical order.
 
 ### Explorers
 
+- [AA Explorer](https://aaexplorer.com/)
 - [AAScan](https://aascan.org)
 - [Blocknative](https://4337.blocknative.com/)
 - [DeCommas REST API (no UI)](https://build.decommas.io)


### PR DESCRIPTION
Added aaexplorer.com to list of Explorers.

(Not sure if alphabetically it should go before or after AAScan. I've put it before..)