### PR TITLE
Add walletkit to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Projects using Account Abstraction (or variations of AA) in alphabetical order.
 - [Timeless](https://timelesswallet.xyz)
 - [TrueWallet](https://true-wallet.io/)
 - [Unipass](https://www.unipass.id/)
+- [WalletKit](https://walletkit.com)
 - [ZeroDev](http://zerodev.app/)
 - [zkSync](https://zksync.io/)
 


### PR DESCRIPTION
Hi team, this PR adds [WalletKit](https://walletkit.com/) to the Projects section, WalletKit provides all in one support for account abstraction, including aa wallet, paymaster, bundler.

We're here to answer any questions. Thanks!