### PR TITLE
Added Blockscout explorer to the list of explorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Projects using Account Abstraction (or variations of AA) in alphabetical order.
 - [Blocknative](https://4337.blocknative.com/)
 - [DeCommas REST API (no UI)](https://build.decommas.io)
 - [Jiffyscan](https://app.jiffyscan.xyz/?selectedNetwork=mainnet)
+- [Blockscout] (https://eth.blockscout.com/ops)
 
 ### Debuggers
 - [Userop.dev](https://userop.dev/)


### PR DESCRIPTION
Blockscout supports AA on more that 14 chains, and Ethereum instance is a great example of that