### PR TITLE
Add Account Abstraction Roadmap article

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [Account Abstraction Deep Dive by Alchemy](https://www.alchemy.com/blog/account-abstraction)
 - [Account Abstraction Decoded by Blocktheory](https://blocktheory.com/decoded/account-abstraction-use-cases)
 - [Deconstructing Account Abstraction by cyber•Fund](https://cyber.fund/content/AA)
+- [Charting Ethereum's Account Abstraction Roadmap I: EIP-3074 & EIP-7702](https://research.2077.xyz/charting-ethereums-account-abstraction-roadmap-i-eip-3074-eip-7702)
 
 ### Ethereum Improvement Proposals (EIPs)
 


### PR DESCRIPTION
Adding a comprehensive article about Ethereum's Account Abstraction roadmap and proposals.

[Charting Ethereum's Account Abstraction Roadmap](https://research.2077.xyz/charting-ethereums-account-abstraction-roadmap-i-eip-3074-eip-7702) - An in-depth exploration of Ethereum's Account Abstraction evolution, analyzing key proposals like EIP-3074 and EIP-7702.