### PR TITLE
chore: Add 429, twitter -> x, etherspot upd

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -15,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.5.1
         with:
-          args: --accept 200,403 README.md
+          args: --accept 200,403,429 README.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@
 - [AA as Ethereum’s broadband moment, by @loaf](https://mirror.xyz/proofedloaf.eth/uJYBCOXoq0YfhKh0HrfwbA4yNV-jbvoeFiOnXDhs2Gc)
 - [Account Abstraction is NOT coming](https://safe.mirror.xyz/9KmZjEbFkmI79s28d9xar6JWYrE50F5AHpa5CR12YGI)
 - [ERC-4337 — Misconceptions and Valid Concerns](https://docs.zerodev.app/blog/erc-4337-misconceptions-and-valid-concerns)
-- [Limitations of AA by Pete J Kim P1](https://twitter.com/petejkim/status/1529604590882234368)
-- [Limitations of AA by Pete J Kim P2](https://twitter.com/petejkim/status/1527027583254241280)
+- [Limitations of AA by Pete J Kim P1](https://x.com/petejkim/status/1529604590882234368)
+- [Limitations of AA by Pete J Kim P2](https://x.com/petejkim/status/1527027583254241280)
 - [Random thoughts on Account Abstraction](https://hackmd.io/@s0lness/BJUb16Yo9)
 - [The current state of Account Abstraction](https://mirror.xyz/plusminushalf.eth/MIThq8Ford5O3b0hDA4LR_tsRteDfazRfpVQXOR3Euk)
 - [Starkware Discussion on AA P1](https://community.starknet.io/t/starknet-account-abstraction-model-part-1/781)
@@ -82,18 +82,18 @@
 
 ### Twitter Threads
 
-- [zkSync2.0 x Account Abstraction](https://twitter.com/zksync/status/1584924198907977728) by @zksync
-- [🧵Thread: The inevitable adoption of account abstraction ](https://twitter.com/Crypto__Jesus_/status/1606307436406636547) by @Crypto\__Jesus_
-- [why hasn't crypto taken off?](https://twitter.com/divine_economy/status/1605230807299543041) by @divine_economy
-- [The concept and dynamics of Abstraction Account(AA) development](https://twitter.com/0xYolo/status/1584447321147789317) by @0xYolo
-- [EIP-4337 Account Abstraction](https://twitter.com/_nishil_/status/1579550419944058880) by @_nishil_
-- [How to try to scam your scammer](https://twitter.com/0x_ARK/status/1553395019884535809) by @0x_ARK
-- [What exactly is AA, and what’s the use case there? A thread for beginners into AA 🧵](https://twitter.com/Mulan0x/status/1583813663986577408) by @Mulan0x
-- [decentralized fee market](https://twitter.com/VitalikButerin/status/1576199517434949634) by @VitalikButerin
-- [MPC vs smart contract wallets: comparison thread](https://twitter.com/Ivshti/status/1529474442622947328) by @Ivshti
-- [4337 Misconceptions](https://twitter.com/johnrising_/status/1619166915624112131) by [@John Rising](https://twitter.com/johnrising_)
-- [Bundler P2P Network](https://twitter.com/ch4r10t33r/status/1658443645215727618) by [@Partha](https://twitter.com/ch4r10t33r)
-- [Top ERC-4337 Bundlers](https://twitter.com/bl00dy1337/status/1691415580539039744) by [@Bloody](https://twitter.com/bl00dy1337)
+- [zkSync2.0 x Account Abstraction](https://x.com/zksync/status/1584924198907977728) by @zksync
+- [🧵Thread: The inevitable adoption of account abstraction ](https://x.com/Crypto__Jesus_/status/1606307436406636547) by @Crypto\__Jesus_
+- [why hasn't crypto taken off?](https://x.com/divine_economy/status/1605230807299543041) by @divine_economy
+- [The concept and dynamics of Abstraction Account(AA) development](https://x.com/0xYolo/status/1584447321147789317) by @0xYolo
+- [EIP-4337 Account Abstraction](https://x.com/_nishil_/status/1579550419944058880) by @_nishil_
+- [How to try to scam your scammer](https://x.com/0x_ARK/status/1553395019884535809) by @0x_ARK
+- [What exactly is AA, and what’s the use case there? A thread for beginners into AA 🧵](https://x.com/Mulan0x/status/1583813663986577408) by @Mulan0x
+- [decentralized fee market](https://x.com/VitalikButerin/status/1576199517434949634) by @VitalikButerin
+- [MPC vs smart contract wallets: comparison thread](https://x.com/Ivshti/status/1529474442622947328) by @Ivshti
+- [4337 Misconceptions](https://x.com/johnrising_/status/1619166915624112131) by [@John Rising](https://x.com/johnrising_)
+- [Bundler P2P Network](https://x.com/ch4r10t33r/status/1658443645215727618) by [@Partha](https://x.com/ch4r10t33r)
+- [Top ERC-4337 Bundlers](https://x.com/bl00dy1337/status/1691415580539039744) by [@Bloody](https://x.com/bl00dy1337)
 
 # Videos
 
@@ -124,7 +124,6 @@
 ### SDK & Libraries
 
 - [0xpass/0xpass](https://github.com/0xpass/0xpass)
-- [aarc-xyz/aarc-sdk](https://github.com/aarc-xyz/aarc-sdk)
 - [alchemyplatform/aa-sdk](https://github.com/alchemyplatform/aa-sdk)
 - [AmbireTech/wallet-login-sdk](https://github.com/AmbireTech/wallet-login-sdk)
 - [AmbireTech/signature-validator](https://github.com/AmbireTech/signature-validator/)
@@ -135,6 +134,7 @@
 - [Dynamic w/ Zerodev](https://docs.dynamic.xyz/embedded-wallets/add-account-abstraction)
 - [eth-infinitism/bundler](https://github.com/eth-infinitism/bundler)
 - [etherspot/prime-sdk](https://github.com/etherspot/etherspot-prime-sdk)
+- [etherspot/modular-sdk](https://github.com/etherspot/etherspot-modular-sdk)
 - [getwax/wax](https://github.com/getwax)
 - [openfort-xyz/openfort-node](https://github.com/openfort-xyz/openfort-node)
 - [porco-rosso-j/zksync-account-trade-limit](https://github.com/porco-rosso-j/zksync-account-trade-limit)
@@ -253,7 +253,7 @@ Projects using Account Abstraction (or variations of AA) in alphabetical order.
 - [rhinestone](https://rhinestone.wtf)
 - [Safe](https://safe.global/)
 - [Solon Network](https://www.solon.network/)
-- [Soul Wallet](https://twitter.com/soulwallet_eth)
+- [Soul Wallet](https://x.com/soulwallet_eth)
 - [Stackup](https://stackup.fi/)
 - [Squence](https://sequence.app/)
 - [thirdweb](https://thirdweb.com/)
@@ -288,8 +288,8 @@ Projects using Account Abstraction (or variations of AA) in alphabetical order.
 
 ### Twitter / Farcaster
 
-- [Official Twitter account for ERC-4337 Account Abstraction](https://twitter.com/erc4337)
-- [4337Mafia Twitter account](https://twitter.com/4337Mafia)
+- [Official Twitter account for ERC-4337 Account Abstraction](https://x.com/erc4337)
+- [4337Mafia Twitter account](https://x.com/4337Mafia)
 - [4337Mafia Farcaster account](https://warpcast.com/4337mafia)
 
 ### Discord
@@ -299,7 +299,7 @@ Projects using Account Abstraction (or variations of AA) in alphabetical order.
 
 ### Newsletters
 
-- [Everything About Account Abstraction](https://medium.com/etherspot/search?q=Everything+About+Account) by Etherspot
+- [All About Abstraction](https://medium.com/search?q=All+About+Abstraction) by Etherspot
 
 ### Research and technical forums
 


### PR DESCRIPTION
- Added 429 to linkchecker action (fixes https://github.com/4337Mafia/awesome-account-abstraction/issues/550) 
- Update twitter.com to x.com
- Removed https://github.com/aarc-xyz/aarc-sdk as it shows "not found"
- Updated "Everything About Account Abstraction" to "All About Abstraction"
- Added Modular SDK by Etherspot