### PR TITLE
Add 7/Seven Chain Node — EVM perpetual futures blockchain (Chain ID: 70007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Projects using Account Abstraction (or variations of AA) in alphabetical order.
 - [WalletKit](https://walletkit.com)
 - [ZeroDev](http://zerodev.app/)
 - [zkSync](https://zksync.io/)
+- [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) - Validator node for 7/Seven Chain (Chain ID: 70007), an EVM-compatible blockchain (BSC/Parlia fork) powering [TheSeven.meme](https://theseven.meme) — world's first on-chain perpetual futures exchange with 100+ pairs, up to 2001× leverage, and zero trading fees.
 
 ### Explorers
 


### PR DESCRIPTION
## 7/Seven Chain Node

Adding [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) to this list.

**What is it?**
7/Seven Chain is an EVM-compatible blockchain (BSC/Parlia consensus fork, Chain ID: 70007) that powers [TheSeven.meme](https://theseven.meme), a perpetual futures exchange with:
- 100+ trading pairs (BTC, ETH, DOGE, PEPE, SHIB, and 95+ more)
- Up to **2001× leverage**
- **Zero trading fees**
- On-chain settlement — funds go directly to your wallet on win

**Validator Node Repo:**
The [seven-chain-node](https://github.com/umairkhan2582/seven-chain-node) repository contains everything needed to run a validator node on 7/Seven Chain Mainnet — genesis config, RPC setup, and validator registration.

**Links:**
- Node Repo: https://github.com/umairkhan2582/seven-chain-node
- Exchange: https://theseven.meme
- Chain ID: 70007 | RPC: https://rpc.theseven.meme
- Explorer: https://theseven.meme/blockchain/explorer

This fits the list as an EVM-compatible blockchain with a live production exchange and active validator set.