### PR TITLE
Add Limonata PasskeyAccount (WebAuthn / RIP-7212 smart account)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 - [Forum Wallet](https://github.com/forumdaos/forum-contracts)
 - [Infinitism](https://github.com/eth-infinitism/account-abstraction)
 - [Kriptonio](https://kriptonio.com)
+- [Limonata PasskeyAccount](https://github.com/Limonata-Blockchain/limonata-passkey-contracts) - Smart-account wallet that verifies WebAuthn/passkey (P-256) signatures on-chain via the RIP-7212 precompile.
 - [Openfort](https://github.com/openfort-xyz/openfort-contracts)
 - [Patch Wallet](https://github.com/PaymagicXYZ/patch-base-account-contracts)
 - [Safe](https://github.com/safe-global/safe-contracts/)


### PR DESCRIPTION
Adds **Limonata PasskeyAccount** under Smart Contracts (EVM).

It is a minimal smart-account wallet that verifies WebAuthn / passkey (P-256) signatures fully on-chain via the RIP-7212 precompile (`0x100`), so users sign with Face ID / Touch ID (no seed phrase). Open source (MIT): https://github.com/Limonata-Blockchain/limonata-passkey-contracts

There is very little passkey/WebAuthn content in the list so far, so hopefully a useful addition. Live demo: https://limonata.xyz/passkey